### PR TITLE
Add i18n support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "classnames": "^2.3.1",
         "format-duration": "^2.0.0",
         "framer-motion": "^7.2.1",
+        "i18next": "^21.9.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.34.2",
+        "react-i18next": "^11.18.6",
         "react-icons": "^4.4.0"
       },
       "devDependencies": {
@@ -34,6 +36,7 @@
         "@typescript-eslint/parser": "^5.36.1",
         "autoprefixer": "^10.4.8",
         "babel-loader": "^8.2.5",
+        "babel-plugin-i18next-extract": "^0.9.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.1",
@@ -41,10 +44,12 @@
         "eslint-plugin-react": "^7.31.1",
         "html-loader": "^4.1.0",
         "html-webpack-plugin": "^5.5.0",
+        "junk": "^4.0.0",
         "postcss-loader": "^7.0.1",
         "style-loader": "^3.3.1",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0"
+        "webpack-cli": "^4.10.0",
+        "webpack-target-webextension": "^1.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4157,24 +4162,16 @@
       "integrity": "sha512-PeaBcTmdZWcFf7n1aM+oiOdZc+sy14qi0emPIeUuGMTjbP0xLGrZu43kdpHnWSXy7/r4Ubp/vlg50MCV8+9Isg=="
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -4451,6 +4448,36 @@
       "dev": true,
       "dependencies": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "node_modules/babel-plugin-i18next-extract": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.9.0.tgz",
+      "integrity": "sha512-i/kcv6YlYFvUR8rICPBxP4xQXenFOGe+84hzYLXItJYrLlimph4lne6hoZXYgaU3mVJmtRokcBmn4RvcitizXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.18.9",
+        "@babel/types": "7.18.10",
+        "deepmerge": "^4.2.2",
+        "i18next": "^21.8.14",
+        "json-stable-stringify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/babel-plugin-i18next-extract/node_modules/@babel/types": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
+      "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.18.10",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -5794,6 +5821,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/espree/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -6406,6 +6445,14 @@
         "node": ">= 12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -6455,6 +6502,28 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "21.9.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.1.tgz",
+      "integrity": "sha512-ITbDrAjbRR73spZAiu6+ex5WNlHRr1mY+acDi2ioTHuUiviJqSz269Le1xHAf0QaQ6GgIHResUhQNcxGwa/PhA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "node_modules/icss-utils": {
@@ -6921,6 +6990,15 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
+      "dev": true,
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6938,6 +7016,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -6949,6 +7036,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/junk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.0.tgz",
+      "integrity": "sha512-ojtSU++zLJ3jQG9bAYjg94w+/DOJtRyD7nPaerMFrBhmdVmiV5/exYH5t4uHga4G/95nT6hr1OJoKIFbYbrW5w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/kind-of": {
@@ -7962,6 +8061,27 @@
         "react": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "11.18.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 19.0.0",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
@@ -8722,6 +8842,18 @@
         }
       }
     },
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -8975,6 +9107,14 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -9104,11 +9244,44 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-target-webextension": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/webpack-target-webextension/-/webpack-target-webextension-1.0.4.tgz",
+      "integrity": "sha512-bxvB7a+R587DY4V39RsmcA04hcBDQAVwNvAITIA5m02wnjwSymF+H1CpHmheSa0HTh3mAp0KPAt4AWzzoUvTkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.17.6"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
     "node_modules/webpack/node_modules/@types/estree": {
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
+    },
+    "node_modules/webpack/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -12166,17 +12339,11 @@
       "integrity": "sha512-PeaBcTmdZWcFf7n1aM+oiOdZc+sy14qi0emPIeUuGMTjbP0xLGrZu43kdpHnWSXy7/r4Ubp/vlg50MCV8+9Isg=="
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "dev": true
-    },
-    "acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
-      "requires": {}
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -12364,6 +12531,32 @@
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-i18next-extract": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.9.0.tgz",
+      "integrity": "sha512-i/kcv6YlYFvUR8rICPBxP4xQXenFOGe+84hzYLXItJYrLlimph4lne6hoZXYgaU3mVJmtRokcBmn4RvcitizXA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.18.9",
+        "@babel/types": "7.18.10",
+        "deepmerge": "^4.2.2",
+        "i18next": "^21.8.14",
+        "json-stable-stringify": "^1.0.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.18.10",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
+          "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.18.10",
+            "@babel/helper-validator-identifier": "^7.18.6",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "babel-plugin-macros": {
@@ -13366,6 +13559,14 @@
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        }
       }
     },
     "esquery": {
@@ -13834,6 +14035,14 @@
         }
       }
     },
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "requires": {
+        "void-elements": "3.1.0"
+      }
+    },
     "html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -13865,6 +14074,14 @@
           "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
           "dev": true
         }
+      }
+    },
+    "i18next": {
+      "version": "21.9.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.1.tgz",
+      "integrity": "sha512-ITbDrAjbRR73spZAiu6+ex5WNlHRr1mY+acDi2ioTHuUiviJqSz269Le1xHAf0QaQ6GgIHResUhQNcxGwa/PhA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "icss-utils": {
@@ -14193,6 +14410,15 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -14204,6 +14430,12 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
+      "dev": true
+    },
     "jsx-ast-utils": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -14213,6 +14445,12 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
       }
+    },
+    "junk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.0.tgz",
+      "integrity": "sha512-ojtSU++zLJ3jQG9bAYjg94w+/DOJtRyD7nPaerMFrBhmdVmiV5/exYH5t4uHga4G/95nT6hr1OJoKIFbYbrW5w==",
+      "dev": true
     },
     "kind-of": {
       "version": "6.0.3",
@@ -14962,6 +15200,15 @@
       "integrity": "sha512-1lYWbEqr0GW7HHUjMScXMidGvV0BE2RJV3ap2BL7G0EJirkqpccTaawbsvBO8GZaB3JjCeFBEbnEWI1P8ZoLRQ==",
       "requires": {}
     },
+    "react-i18next": {
+      "version": "11.18.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+      "requires": {
+        "@babel/runtime": "^7.14.5",
+        "html-parse-stringify": "^3.0.1"
+      }
+    },
     "react-icons": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
@@ -15493,6 +15740,12 @@
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        },
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -15682,6 +15935,11 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true
     },
+    "void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
+    },
     "watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -15729,6 +15987,19 @@
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
           "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
           "dev": true
+        },
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        },
+        "acorn-import-assertions": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+          "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -15767,6 +16038,13 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true
+    },
+    "webpack-target-webextension": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/webpack-target-webextension/-/webpack-target-webextension-1.0.4.tgz",
+      "integrity": "sha512-bxvB7a+R587DY4V39RsmcA04hcBDQAVwNvAITIA5m02wnjwSymF+H1CpHmheSa0HTh3mAp0KPAt4AWzzoUvTkw==",
+      "dev": true,
+      "requires": {}
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "classnames": "^2.3.1",
     "format-duration": "^2.0.0",
     "framer-motion": "^7.2.1",
+    "i18next": "^21.9.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.34.2",
+    "react-i18next": "^11.18.6",
     "react-icons": "^4.4.0"
   },
   "scripts": {
@@ -47,6 +49,7 @@
     "@typescript-eslint/parser": "^5.36.1",
     "autoprefixer": "^10.4.8",
     "babel-loader": "^8.2.5",
+    "babel-plugin-i18next-extract": "^0.9.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",
@@ -54,9 +57,11 @@
     "eslint-plugin-react": "^7.31.1",
     "html-loader": "^4.1.0",
     "html-webpack-plugin": "^5.5.0",
+    "junk": "^4.0.0",
     "postcss-loader": "^7.0.1",
     "style-loader": "^3.3.1",
     "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0"
+    "webpack-cli": "^4.10.0",
+    "webpack-target-webextension": "^1.0.4"
   }
 }

--- a/src/common/i18next/ExtensionBackend.ts
+++ b/src/common/i18next/ExtensionBackend.ts
@@ -1,0 +1,15 @@
+import type { BackendModule } from 'i18next'
+
+const ExtensionBackend : () => BackendModule = () => {
+  return {
+    type: 'backend',
+    init() { return },
+    read(language, namespace, callback) {
+      import(`../locales/${language}/${namespace}.json`)
+        .then((resources) => callback(null, resources))
+        .catch((error) => callback(error, null))
+    },
+  }
+}
+
+export default ExtensionBackend

--- a/src/common/i18next/ExtensionLanguageDetect.ts
+++ b/src/common/i18next/ExtensionLanguageDetect.ts
@@ -1,0 +1,22 @@
+import type { LanguageDetectorAsyncModule } from 'i18next'
+
+const ExtensionLanguageDetect : () => LanguageDetectorAsyncModule = () => {
+  return {
+    type: 'languageDetector',
+    async: true,
+    init(services) {
+      this.services = services
+    },
+    async detect(callback) {
+      const { language } = await chrome.storage.local.get('language')
+      if (language) return callback(language)
+  
+      callback(this.services.languageUtils.getBestMatchFromCodes(await chrome.i18n.getAcceptLanguages()))
+    },
+    async cacheUserLanguage(language) {
+      await chrome.storage.local.set({ language })
+    },
+  }
+}
+
+export default ExtensionLanguageDetect

--- a/src/common/i18next/index.ts
+++ b/src/common/i18next/index.ts
@@ -12,7 +12,7 @@ i18n
     fallbackLng: 'en-US',
     interpolation: {
       escapeValue: false,
-    }
+    },
   })
 
 export default i18n

--- a/src/common/i18next/index.ts
+++ b/src/common/i18next/index.ts
@@ -1,0 +1,18 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import ExtensionLanguageDetect from './ExtensionLanguageDetect'
+import ExtensionBackend from './ExtensionBackend'
+
+i18n
+  .use(ExtensionLanguageDetect())
+  .use(ExtensionBackend())
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en-US',
+    interpolation: {
+      escapeValue: false,
+    }
+  })
+
+export default i18n

--- a/src/common/locales/en-US/content.json
+++ b/src/common/locales/en-US/content.json
@@ -1,0 +1,10 @@
+{
+  "dexLink": {
+    "title": "Open in Holodex"
+  },
+  "songsPanel": {
+    "header": {
+      "title": "Songs"
+    }
+  }
+}

--- a/src/common/locales/en-US/options.json
+++ b/src/common/locales/en-US/options.json
@@ -12,7 +12,7 @@
     "label": "Show Holodex button in player"
   },
   "showSongControls": {
-    "label": "Show song controls"
+    "label": "Show playback controls"
   },
   "submit": {
     "noChanges": "No changes to save",

--- a/src/common/locales/en-US/options.json
+++ b/src/common/locales/en-US/options.json
@@ -1,0 +1,21 @@
+{
+  "apiKey": {
+    "errors": {
+      "invalidKey": "Invalid API key. Please check your key and try again.",
+      "serverError": "There was an error validating your API key. Please try again later."
+    },
+    "helper": "Get your API key from your <1>account settings <1></1></1>",
+    "label": "API Key"
+  },
+  "savedChanges": "Your changes were saved",
+  "showDexButton": {
+    "label": "Show Holodex button in player"
+  },
+  "showSongControls": {
+    "label": "Show song controls"
+  },
+  "submit": {
+    "noChanges": "No changes to save",
+    "title": "Save"
+  }
+}

--- a/src/common/locales/ja-JP/content.json
+++ b/src/common/locales/ja-JP/content.json
@@ -1,0 +1,10 @@
+{
+  "dexLink": {
+    "title": "Holodex で開く"
+  },
+  "songsPanel": {
+    "header": {
+      "title": "楽曲"
+    }
+  }
+}

--- a/src/common/locales/ja-JP/options.json
+++ b/src/common/locales/ja-JP/options.json
@@ -1,0 +1,21 @@
+{
+  "apiKey": {
+    "errors": {
+      "invalidKey": "APIキーが無効です。ご確認の上、再度お試しください。",
+      "serverError": "問題が発生しました。後ほどもう一度お試しください。"
+    },
+    "helper": "APIキーは <1>アカウント設定<1></1></1> から取得してください",
+    "label": "APIキー"
+  },
+  "savedChanges": "変更の保存に成功しました",
+  "showDexButton": {
+    "label": "Holodex ボタンを表示する"
+  },
+  "showSongControls": {
+    "label": "メディアコントロールを表示する"
+  },
+  "submit": {
+    "noChanges": "変更なし",
+    "title": "保存"
+  }
+}

--- a/src/common/locales/zh-CN/content.json
+++ b/src/common/locales/zh-CN/content.json
@@ -1,0 +1,10 @@
+{
+  "dexLink": {
+    "title": "在 Holodex 上打开"
+  },
+  "songsPanel": {
+    "header": {
+      "title": "歌单"
+    }
+  }
+}

--- a/src/common/locales/zh-CN/options.json
+++ b/src/common/locales/zh-CN/options.json
@@ -1,0 +1,21 @@
+{
+  "apiKey": {
+    "errors": {
+      "invalidKey": "该密钥无效，请检查后重试。",
+      "serverError": "出了点问题，请稍后重试。"
+    },
+    "helper": "您可以从 <1>账号设置<1></1></1> 获取您的API密钥",
+    "label": "API密钥"
+  },
+  "savedChanges": "更改已成功保存",
+  "showDexButton": {
+    "label": "显示 Holodex 链接"
+  },
+  "showSongControls": {
+    "label": "显示回放控制"
+  },
+  "submit": {
+    "noChanges": "没有更改可保存",
+    "title": "保存"
+  }
+}

--- a/src/common/locales/zh-TW/content.json
+++ b/src/common/locales/zh-TW/content.json
@@ -1,0 +1,10 @@
+{
+  "dexLink": {
+    "title": "於 Holodex 開啟"
+  },
+  "songsPanel": {
+    "header": {
+      "title": "歌單"
+    }
+  }
+}

--- a/src/common/locales/zh-TW/options.json
+++ b/src/common/locales/zh-TW/options.json
@@ -1,0 +1,21 @@
+{
+  "apiKey": {
+    "errors": {
+      "invalidKey": "此密鑰無效，請檢查並重試。",
+      "serverError": "出了點問題，請稍後重試。"
+    },
+    "helper": "您可以從 <1>帳號設定<1></1></1> 取得您的API密鑰",
+    "label": "API密鑰"
+  },
+  "savedChanges": "更改已成功保存",
+  "showDexButton": {
+    "label": "顯示 Holodex 鏈接"
+  },
+  "showSongControls": {
+    "label": "顯示回放控制"
+  },
+  "submit": {
+    "noChanges": "無更改可保存",
+    "title": "保存"
+  }
+}

--- a/src/common/types/BrowserMessage.ts
+++ b/src/common/types/BrowserMessage.ts
@@ -1,6 +1,7 @@
 export enum BrowserMessageType {
   tabStatusChange,
   updateAvailable,
+  languageChanged,
 }
 
 export interface BrowserMessageTabStatusChange {
@@ -13,4 +14,12 @@ export interface BrowserMessageUpdateAvailable {
   version: string,
 }
 
-export type BrowserMessage = BrowserMessageTabStatusChange | BrowserMessageUpdateAvailable
+export interface BrowserMessageLanguageChanged {
+  type: BrowserMessageType.languageChanged,
+}
+
+export type BrowserMessage = (
+  BrowserMessageTabStatusChange |
+  BrowserMessageUpdateAvailable |
+  BrowserMessageLanguageChanged
+)

--- a/src/common/utils/message.ts
+++ b/src/common/utils/message.ts
@@ -1,0 +1,10 @@
+import type { BrowserMessage } from '../../common/types/BrowserMessage'
+
+export const messageOne = async (tabId: number, message: BrowserMessage) => {
+  return chrome.tabs.sendMessage(tabId, message).catch(() => null)
+}
+
+export const messageAll = async (message: BrowserMessage) => {
+  const tabs = await chrome.tabs.query({ url: '<all_urls>' })
+  return Promise.allSettled(tabs.map(tab => chrome.tabs.sendMessage(tab.id, message)))
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,5 +25,12 @@
   "background": {
     "service_worker": "background.js",
     "type": "module"
-  }
+  },
+
+  "web_accessible_resources": [
+    {
+      "resources": ["*.js"],
+      "matches": ["*://*.youtube.com/*"]
+    }
+  ]
 }

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -1,4 +1,5 @@
 import { BrowserMessageType } from '../../common/types/BrowserMessage'
+import { messageOne, messageAll } from '../../common/utils/message'
 
 chrome.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
@@ -6,14 +7,12 @@ chrome.runtime.onInstalled.addListener(({ reason }) => {
   }
 })
 
-chrome.runtime.onUpdateAvailable.addListener(async ({ version }) => {
-  const tabs = await chrome.tabs.query({ url: '<all_urls>' })
-  Promise.allSettled(tabs.map(tab => chrome.tabs.sendMessage(tab.id, { type: BrowserMessageType.updateAvailable, version })))
+chrome.runtime.onUpdateAvailable.addListener(({ version }) => {
+  messageAll({ type: BrowserMessageType.updateAvailable, version })
 })
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
   if (changeInfo.status) {
-    chrome.tabs.sendMessage(tabId, { type: BrowserMessageType.tabStatusChange, status: changeInfo.status })
-      .catch(() => null)
+    messageOne(tabId, { type: BrowserMessageType.tabStatusChange, status: changeInfo.status })
   }
 })

--- a/src/pages/content/DexLink.tsx
+++ b/src/pages/content/DexLink.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import cx from 'classnames'
 
 import styles from './DexLink.module.scss'
@@ -8,11 +9,13 @@ export interface DexLinkProps {
 }
 
 const DexLink = ({ onClick } : DexLinkProps) => {
+  const { t } = useTranslation('content')
+
   return (
     <button
       className={cx(styles.dexlinkBtn, 'ytp-button')}
       onClick={onClick}
-      title='Open in Holodex'>
+      title={t('dexLink.title')}>
       <HolodexLogo width='2em' height='2em' />
     </button>
   )

--- a/src/pages/content/SongsPanel.tsx
+++ b/src/pages/content/SongsPanel.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import useStorage from '../../hooks/useStorage'
 import { Song, RepeatMode, MusicMode } from './Content'
 import YoutubePanel, { YoutubePanelHeader, YoutubePanelListContent, YoutubePanelFooter } from './YoutubePanel'
@@ -38,11 +40,12 @@ const SongsPanel = ({
   onToggleRepeatMode,
   onToggleMusicMode,
 }: SongsPanelProps) => {
+  const { t } = useTranslation('content')
   const [showSongControls] = useStorage('showSongControls', true)
 
   return (
     <YoutubePanel>
-      <YoutubePanelHeader title='Songs' />
+      <YoutubePanelHeader title={t('songsPanel.header.title')} />
       <YoutubePanelListContent>
         {
           songs.map((song) => (

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -1,5 +1,7 @@
 import { createRoot } from 'react-dom/client'
 
+import '../../common/i18next'
+
 import { BrowserMessageType, type BrowserMessage } from '../../common/types/BrowserMessage'
 import { ensureSelector, injectElement } from '../../common/utils/dom-watch'
 import Content from './Content'

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client'
 
-import '../../common/i18next'
+import i18n from '../../common/i18next'
 
 import { BrowserMessageType, type BrowserMessage } from '../../common/types/BrowserMessage'
 import { ensureSelector, injectElement } from '../../common/utils/dom-watch'
@@ -26,6 +26,9 @@ import Content from './Content'
       if (message.status !== 'complete' || id === videoId) return
       videoId = id
       break
+    case BrowserMessageType.languageChanged:
+      i18n.changeLanguage()
+      return
     default:
       return
     }

--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -25,6 +25,8 @@ import {
 } from '@chakra-ui/react'
 
 import useStorage from '../../hooks/useStorage'
+import { BrowserMessageType } from '../../common/types/BrowserMessage'
+import { messageAll } from '../../common/utils/message'
 
 const Options = () => {
   const [ t, i18n ] = useTranslation('options')
@@ -71,8 +73,9 @@ const Options = () => {
     })
   }
 
-  const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    i18n.changeLanguage(e.target.value)
+  const handleLanguageChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    await i18n.changeLanguage(e.target.value)
+    messageAll({ type: BrowserMessageType.languageChanged })
   }
 
   const onSubmit = async (prefs) => {

--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -149,6 +149,9 @@ const Options = () => {
       <Flex>
         <Select variant='filled' onChange={handleLanguageChange} defaultValue={i18n.language} display='inline-block' width='auto'>
           <option value='en-US'>English</option>
+          <option value='ja-JP'>日本語</option>
+          <option value='zh-CN'>中文（简体）</option>
+          <option value='zh-TW'>中文（繁體）</option>
         </Select>
 
         <Spacer />

--- a/src/pages/options/index.tsx
+++ b/src/pages/options/index.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 
+import '../../common/i18next'
 import { ChakraProvider } from '@chakra-ui/react'
 
 import './index.scss'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2015",
+    "module": "esnext",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "noEmit": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,12 @@
+import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import WebExtensionPlugin from 'webpack-target-webextension'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import CopyWebpackPlugin from 'copy-webpack-plugin'
 import { CleanWebpackPlugin } from 'clean-webpack-plugin'
+import { isNotJunk } from 'junk'
 
 import packageJson from './package.json' assert {type: 'json'}
 
@@ -21,6 +24,9 @@ const config = {
   output: {
     path: path.join(__dirname, 'dist'),
     filename: '[name].js',
+    environment: {
+      dynamicImport: true,
+    }
   },
   
   module: {
@@ -38,6 +44,15 @@ const config = {
                 '@babel/preset-env',
                 ['@babel/preset-react', { runtime: 'automatic' }],
                 '@babel/preset-typescript',
+              ],
+              plugins: [
+                ['i18next-extract', {
+                  locales: fs.readdirSync(path.join(__dirname, 'src', 'common', 'locales')).filter(isNotJunk),
+                  outputPath: path.resolve(__dirname, 'src', 'common', 'locales', '{{locale}}', '{{ns}}.json'),
+                  defaultValue: null,
+                  useI18nextDefaultValue: true,
+                  discardOldKeys: true,
+                }],
               ],
             },
           },
@@ -120,6 +135,9 @@ const config = {
       template: path.join(__dirname, 'src', 'pages', 'options', 'index.html'),
       filename: 'options.html',
       chunks: ['options'],
+    }),
+    new WebExtensionPlugin({
+      weakRuntimeCheck: true,
     }),
   ],
 


### PR DESCRIPTION
This PR adds i18n support through `react-i18next`.  Default is chosen using `chrome.i18n.getAcceptLanguages()` but can be changed from a new dropdown in Options. 

Currently supports `en-US`, `ja-JP`, `zh-CN`, and `zh-TW`. 

Closes #2. 

