### PR TITLE
Add whitelisting by channel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "array-filter-inplace": "^1.0.1",
+        "async-mutex": "^0.4.0",
         "classnames": "^2.3.1",
         "format-duration": "^2.0.0",
         "framer-motion": "^7.2.1",
@@ -4315,6 +4316,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -12232,6 +12241,14 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "autoprefixer": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "array-filter-inplace": "^1.0.1",
+    "async-mutex": "^0.4.0",
     "classnames": "^2.3.1",
     "format-duration": "^2.0.0",
     "framer-motion": "^7.2.1",

--- a/src/common/locales/en-US/options.json
+++ b/src/common/locales/en-US/options.json
@@ -9,7 +9,7 @@
     "label": "API Key"
   },
   "enableWhitelist": {
-    "helper": "Only query the API when watching channels tracked by Holodex. This requires maintaining a local list of channels which must be updated from time to time (for example, after a debut).",
+    "helper": "Only query the API when watching channels tracked by Holodex. ",
     "label": "Limit API requests"
   },
   "savedChanges": "Your changes were saved",

--- a/src/common/locales/en-US/options.json
+++ b/src/common/locales/en-US/options.json
@@ -8,6 +8,10 @@
     "helper": "Get your API key from your <1>account settings <1></1></1>",
     "label": "API Key"
   },
+  "enableWhitelist": {
+    "helper": "Only query the API when watching channels tracked by Holodex. This requires maintaining a local list of channels which must be updated from time to time (for example, after a debut).",
+    "label": "Limit API requests"
+  },
   "savedChanges": "Your changes were saved",
   "showDexButton": {
     "label": "Show Holodex button in player"
@@ -25,5 +29,11 @@
       "loading": "Updating channels...",
       "success": "Updated channels successfully"
     }
+  },
+  "whitelistStat": {
+    "label": "Channels",
+    "lastUpdated": "Updated {{lastUpdated, datetime(dateStyle: medium)}}",
+    "lastUpdatedNever": "Never updated",
+    "length": "{{length, number}}"
   }
 }

--- a/src/common/locales/en-US/options.json
+++ b/src/common/locales/en-US/options.json
@@ -18,5 +18,12 @@
   "submit": {
     "noChanges": "No changes to save",
     "title": "Save"
+  },
+  "updateChannels": {
+    "title": {
+      "default": "Update channels list",
+      "loading": "Updating channels...",
+      "success": "Updated channels successfully"
+    }
   }
 }

--- a/src/common/locales/ja-JP/options.json
+++ b/src/common/locales/ja-JP/options.json
@@ -18,5 +18,12 @@
   "submit": {
     "noChanges": "変更なし",
     "title": "保存"
+  },
+  "updateChannels": {
+    "title": {
+      "default": null,
+      "loading": null,
+      "success": null
+    }
   }
 }

--- a/src/common/locales/ja-JP/options.json
+++ b/src/common/locales/ja-JP/options.json
@@ -9,8 +9,8 @@
     "label": "APIキー"
   },
   "enableWhitelist": {
-    "helper": null,
-    "label": null
+    "helper": "Holodexに登録されているチャンネルを視聴している場合だけAPIを呼び出す。",
+    "label": "APIリクエストを制限する"
   },
   "savedChanges": "変更の保存に成功しました",
   "showDexButton": {
@@ -25,15 +25,15 @@
   },
   "updateChannels": {
     "title": {
-      "default": null,
-      "loading": null,
-      "success": null
+      "default": "チャンネルリストを更新",
+      "loading": "更新中...",
+      "success": "リストを更新しました"
     }
   },
   "whitelistStat": {
-    "label": null,
-    "lastUpdated": null,
-    "lastUpdatedNever": null,
-    "length": null
+    "label": "チャンネル",
+    "lastUpdated": "{{lastUpdated, datetime(dateStyle: medium)}} 最終更新",
+    "lastUpdatedNever": "更新されていない",
+    "length": "{{length, number}}"
   }
 }

--- a/src/common/locales/ja-JP/options.json
+++ b/src/common/locales/ja-JP/options.json
@@ -8,6 +8,10 @@
     "helper": "APIキーは <1>アカウント設定<1></1></1> から取得してください",
     "label": "APIキー"
   },
+  "enableWhitelist": {
+    "helper": null,
+    "label": null
+  },
   "savedChanges": "変更の保存に成功しました",
   "showDexButton": {
     "label": "Holodex ボタンを表示する"
@@ -25,5 +29,11 @@
       "loading": null,
       "success": null
     }
+  },
+  "whitelistStat": {
+    "label": null,
+    "lastUpdated": null,
+    "lastUpdatedNever": null,
+    "length": null
   }
 }

--- a/src/common/locales/zh-CN/options.json
+++ b/src/common/locales/zh-CN/options.json
@@ -9,8 +9,8 @@
     "label": "API密钥"
   },
   "enableWhitelist": {
-    "helper": null,
-    "label": null
+    "helper": "将API访问限制为受Holodex跟踪的频道。",
+    "label": "限制API访问"
   },
   "savedChanges": "更改已成功保存",
   "showDexButton": {
@@ -25,15 +25,15 @@
   },
   "updateChannels": {
     "title": {
-      "default": null,
-      "loading": null,
-      "success": null
+      "default": "更新频道列表",
+      "loading": "更新中...",
+      "success": "更新成功"
     }
   },
   "whitelistStat": {
-    "label": null,
-    "lastUpdated": null,
-    "lastUpdatedNever": null,
-    "length": null
+    "label": "频道",
+    "lastUpdated": "{{lastUpdated, datetime(dateStyle: medium)}} 最后更新",
+    "lastUpdatedNever": "没更新过",
+    "length": "{{length, number}}"
   }
 }

--- a/src/common/locales/zh-CN/options.json
+++ b/src/common/locales/zh-CN/options.json
@@ -8,6 +8,10 @@
     "helper": "您可以从 <1>账号设置<1></1></1> 获取您的API密钥",
     "label": "API密钥"
   },
+  "enableWhitelist": {
+    "helper": null,
+    "label": null
+  },
   "savedChanges": "更改已成功保存",
   "showDexButton": {
     "label": "显示 Holodex 链接"
@@ -25,5 +29,11 @@
       "loading": null,
       "success": null
     }
+  },
+  "whitelistStat": {
+    "label": null,
+    "lastUpdated": null,
+    "lastUpdatedNever": null,
+    "length": null
   }
 }

--- a/src/common/locales/zh-CN/options.json
+++ b/src/common/locales/zh-CN/options.json
@@ -18,5 +18,12 @@
   "submit": {
     "noChanges": "没有更改可保存",
     "title": "保存"
+  },
+  "updateChannels": {
+    "title": {
+      "default": null,
+      "loading": null,
+      "success": null
+    }
   }
 }

--- a/src/common/locales/zh-TW/options.json
+++ b/src/common/locales/zh-TW/options.json
@@ -9,8 +9,8 @@
     "label": "API密鑰"
   },
   "enableWhitelist": {
-    "helper": null,
-    "label": null
+    "helper": "將API訪問限制為受Holodex跟踪的頻道。",
+    "label": "限制API訪問"
   },
   "savedChanges": "更改已成功保存",
   "showDexButton": {
@@ -25,15 +25,15 @@
   },
   "updateChannels": {
     "title": {
-      "default": null,
-      "loading": null,
-      "success": null
+      "default": "更新頻道列表",
+      "loading": "更新中...",
+      "success": "更新成功"
     }
   },
   "whitelistStat": {
-    "label": null,
-    "lastUpdated": null,
-    "lastUpdatedNever": null,
-    "length": null
+    "label": "頻道",
+    "lastUpdated": "{{lastUpdated, datetime(dateStyle: medium)}} 最後更新",
+    "lastUpdatedNever": "沒更新過",
+    "length": "{{length, number}}"
   }
 }

--- a/src/common/locales/zh-TW/options.json
+++ b/src/common/locales/zh-TW/options.json
@@ -18,5 +18,12 @@
   "submit": {
     "noChanges": "無更改可保存",
     "title": "保存"
+  },
+  "updateChannels": {
+    "title": {
+      "default": null,
+      "loading": null,
+      "success": null
+    }
   }
 }

--- a/src/common/locales/zh-TW/options.json
+++ b/src/common/locales/zh-TW/options.json
@@ -8,6 +8,10 @@
     "helper": "您可以從 <1>帳號設定<1></1></1> 取得您的API密鑰",
     "label": "API密鑰"
   },
+  "enableWhitelist": {
+    "helper": null,
+    "label": null
+  },
   "savedChanges": "更改已成功保存",
   "showDexButton": {
     "label": "顯示 Holodex 鏈接"
@@ -25,5 +29,11 @@
       "loading": null,
       "success": null
     }
+  },
+  "whitelistStat": {
+    "label": null,
+    "lastUpdated": null,
+    "lastUpdatedNever": null,
+    "length": null
   }
 }

--- a/src/common/utils/channel-whitelist.ts
+++ b/src/common/utils/channel-whitelist.ts
@@ -1,0 +1,38 @@
+export const WHITELIST_UPDATE_INTERVAL = 60 * 24 * 7 // 1 week
+
+export const updateWhitelist = async () => {
+  const { apiKey, whitelistUpdating } = await chrome.storage.local.get(['apiKey', 'whitelistUpdating'])
+  if (!apiKey || whitelistUpdating) return false
+
+  await chrome.storage.local.set({ whitelistUpdating: true })
+
+  const whitelist: Record<string, boolean> = {}
+
+  let offset = 0
+  const limit = 100
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const channels = await (await fetch(`https://holodex.net/api/v2/channels?type=vtuber&limit=${limit}&offset=${offset}`, {
+        headers: {
+          'X-APIKEY': apiKey as string
+        }
+      })).json() as { id: string }[]
+
+      if (!channels.length) break
+
+      for (const { id } of channels) {
+        whitelist[id] = true
+      }
+
+      offset += channels.length
+    } catch {
+      await chrome.storage.local.set({ whitelistUpdating: false })
+      return false
+    }
+  }
+
+  await chrome.storage.local.set({ whitelist, whitelistLastUpdated: (new Date()).getTime(), whitelistUpdating: false })
+  return true
+}

--- a/src/hooks/useChannelWhitelist.ts
+++ b/src/hooks/useChannelWhitelist.ts
@@ -3,6 +3,7 @@ import useStorage from './useStorage'
 const useChannelWhitelist = () => {
   const [apiKey] = useStorage<string>('apiKey')
   const [whitelist, setWhitelist] = useStorage<Record<string, boolean>>('whitelist', {})
+  const [whitelistLastUpdated, setWhitelistLastUpdated] = useStorage<number>('whitelistLastUpdated')
 
   const isWhitelisted = (channelId: string) => {
     return channelId in whitelist
@@ -28,9 +29,12 @@ const useChannelWhitelist = () => {
     }
 
     setWhitelist(newWhitelist)
+    setWhitelistLastUpdated((new Date()).getTime())
   }
 
-  return { isWhitelisted, updateWhitelist }
+  const lastUpdated = whitelistLastUpdated && new Date(whitelistLastUpdated)
+
+  return { whitelist, isWhitelisted, updateWhitelist, lastUpdated }
 }
 
 export default useChannelWhitelist

--- a/src/hooks/useChannelWhitelist.ts
+++ b/src/hooks/useChannelWhitelist.ts
@@ -1,47 +1,16 @@
-import { useState } from 'react'
-
 import useStorage from './useStorage'
+import { updateWhitelist } from '../common/utils/channel-whitelist'
 
 const useChannelWhitelist = () => {
-  const [apiKey] = useStorage<string>('apiKey')
-  const [whitelist, setWhitelist] = useStorage<Record<string, boolean>>('whitelist', {})
-  const [lastUpdated, setLastUpdated] = useStorage<number>('whitelistLastUpdated')
-  const [isWhitelistUpdating, setIsWhitelistUpdating] = useState(false)
+  const [whitelist] = useStorage<Record<string, boolean>>('whitelist', {})
+  const [lastUpdated] = useStorage<number>('whitelistLastUpdated', 0)
+  const [isWhitelistUpdating] = useStorage('whitelistUpdating', false)
 
   const isWhitelisted = (channelId: string) => {
     return whitelist ? channelId in whitelist : false
   }
 
-  const updateWhitelist = async () => {
-    if (!apiKey) return false
-
-    setIsWhitelistUpdating(true)
-    const newWhitelist: Record<string, boolean> = {}
-
-    let offset = 0
-    const limit = 100
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const channels = await (await fetch(`https://holodex.net/api/v2/channels?type=vtuber&limit=${limit}&offset=${offset}`, {
-        headers: {
-          'X-APIKEY': apiKey
-        }
-      })).json() as { id: string }[]
-      if (!channels.length) break
-
-      for (const { id } of channels) newWhitelist[id] = true
-      offset += channels.length
-    }
-
-    setWhitelist(newWhitelist)
-    setLastUpdated((new Date()).getTime())
-    setIsWhitelistUpdating(false)
-
-    return true
-  }
-
-  const whitelistLastUpdated = lastUpdated && new Date(lastUpdated)
+  const whitelistLastUpdated = lastUpdated ? new Date(lastUpdated) : lastUpdated === undefined ? undefined : null
 
   return { whitelist, isWhitelisted, updateWhitelist, whitelistLastUpdated, isWhitelistUpdating }
 }

--- a/src/hooks/useChannelWhitelist.ts
+++ b/src/hooks/useChannelWhitelist.ts
@@ -1,0 +1,36 @@
+import useStorage from './useStorage'
+
+const useChannelWhitelist = () => {
+  const [apiKey] = useStorage<string>('apiKey')
+  const [whitelist, setWhitelist] = useStorage<Record<string, boolean>>('whitelist', {})
+
+  const isWhitelisted = (channelId: string) => {
+    return channelId in whitelist
+  }
+
+  const updateWhitelist = async () => {
+    const newWhitelist = {}
+
+    let offset = 0
+    const limit = 100
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const channels = await (await fetch(`https://holodex.net/api/v2/channels?type=vtuber&limit=${limit}&offset=${offset}`, {
+        headers: {
+          'X-APIKEY': apiKey
+        }
+      })).json()
+      if (!channels.length) break
+
+      for (const { id } of channels) newWhitelist[id] = true
+      offset += channels.length
+    }
+
+    setWhitelist(newWhitelist)
+  }
+
+  return { isWhitelisted, updateWhitelist }
+}
+
+export default useChannelWhitelist

--- a/src/hooks/useChannelWhitelist.ts
+++ b/src/hooks/useChannelWhitelist.ts
@@ -1,15 +1,19 @@
+import { useState } from 'react'
+
 import useStorage from './useStorage'
 
 const useChannelWhitelist = () => {
   const [apiKey] = useStorage<string>('apiKey')
   const [whitelist, setWhitelist] = useStorage<Record<string, boolean>>('whitelist', {})
-  const [whitelistLastUpdated, setWhitelistLastUpdated] = useStorage<number>('whitelistLastUpdated')
+  const [lastUpdated, setLastUpdated] = useStorage<number>('whitelistLastUpdated')
+  const [isWhitelistUpdating, setIsWhitelistUpdating] = useState(false)
 
   const isWhitelisted = (channelId: string) => {
     return channelId in whitelist
   }
 
   const updateWhitelist = async () => {
+    setIsWhitelistUpdating(true)
     const newWhitelist = {}
 
     let offset = 0
@@ -29,12 +33,13 @@ const useChannelWhitelist = () => {
     }
 
     setWhitelist(newWhitelist)
-    setWhitelistLastUpdated((new Date()).getTime())
+    setLastUpdated((new Date()).getTime())
+    setIsWhitelistUpdating(false)
   }
 
-  const lastUpdated = whitelistLastUpdated && new Date(whitelistLastUpdated)
+  const whitelistLastUpdated = lastUpdated && new Date(lastUpdated)
 
-  return { whitelist, isWhitelisted, updateWhitelist, lastUpdated }
+  return { whitelist, isWhitelisted, updateWhitelist, whitelistLastUpdated, isWhitelistUpdating }
 }
 
 export default useChannelWhitelist

--- a/src/hooks/useStorage.ts
+++ b/src/hooks/useStorage.ts
@@ -17,7 +17,7 @@ const useStorage = <T>(key: string, defaultValue?: T) : [T, (newValue: T) => voi
 
   useEffect(() => {
     storageArea.get(key)
-      .then(({ [key]: value }) => setValue(value))
+      .then(({ [key]: value }) => setValue(value === undefined ? defaultValue : value))
 
     storageArea.onChanged.addListener(handleStorageChange)
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,7 @@
   "name": "Youtube-Holodex",
 
   "permissions": [
+    "alarms",
     "storage"
   ],
   

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -1,9 +1,16 @@
 import { BrowserMessageType } from '../../common/types/BrowserMessage'
 import { messageOne, messageAll } from '../../common/utils/message'
+import { updateWhitelist } from '../../common/utils/channel-whitelist'
 
 chrome.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
     chrome.runtime.openOptionsPage()
+  }
+})
+
+chrome.alarms.onAlarm.addListener(({ name }) => {
+  if (name === 'whitelist-updater') {
+    void updateWhitelist()
   }
 })
 

--- a/src/pages/content/Content.tsx
+++ b/src/pages/content/Content.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 
 import useStorage from '../../hooks/useStorage'
 import useYoutubePlayer from '../../hooks/useYoutubePlayer'
+import useChannelWhitelist from '../../hooks/useChannelWhitelist'
 import SongsPanel from './SongsPanel'
 import DexLink from './DexLink'
 
@@ -30,14 +31,16 @@ export interface Song {
 export interface ContentProps {
   player: HTMLElement,
   videoId: string | null,
+  channelId: string | null,
   songsPanelContainer: HTMLElement,
   dexLinkContainer: HTMLElement,
 }
 
-const Content = ({ player, videoId, songsPanelContainer, dexLinkContainer } : ContentProps) => {
+const Content = ({ player, videoId, channelId, songsPanelContainer, dexLinkContainer } : ContentProps) => {
   const [apiKey] = useStorage<string>('apiKey')
   const [showDexButton] = useStorage('showDexButton', true)
 
+  const { isWhitelisted } = useChannelWhitelist()
   const { video, paused, currentTime, playingAd } = useYoutubePlayer(player)
 
   const [songs, setSongs] = useState<Song[]>([])
@@ -46,7 +49,7 @@ const Content = ({ player, videoId, songsPanelContainer, dexLinkContainer } : Co
   const [musicMode, setMusicMode] = useState(MusicMode.Off)
 
   useEffect(() => {
-    if (!videoId || !apiKey) return setSongs([])
+    if (!videoId || !apiKey || !isWhitelisted(channelId)) return setSongs([])
 
     fetch(`https://holodex.net/api/v2/videos?id=${videoId}&include=songs`, {
       headers: {
@@ -60,7 +63,7 @@ const Content = ({ player, videoId, songsPanelContainer, dexLinkContainer } : Co
       .catch(() => {
         setSongs([])
       })
-  }, [videoId, apiKey])
+  }, [videoId, apiKey, channelId])
 
   useEffect(() => {
     setCurrentSong(null)

--- a/src/pages/content/Content.tsx
+++ b/src/pages/content/Content.tsx
@@ -39,6 +39,7 @@ export interface ContentProps {
 const Content = ({ player, videoId, channelId, songsPanelContainer, dexLinkContainer } : ContentProps) => {
   const [apiKey] = useStorage<string>('apiKey')
   const [showDexButton] = useStorage('showDexButton', true)
+  const [enableWhitelist] = useStorage('enableWhitelist', false)
 
   const { isWhitelisted } = useChannelWhitelist()
   const { video, paused, currentTime, playingAd } = useYoutubePlayer(player)
@@ -49,7 +50,7 @@ const Content = ({ player, videoId, channelId, songsPanelContainer, dexLinkConta
   const [musicMode, setMusicMode] = useState(MusicMode.Off)
 
   useEffect(() => {
-    if (!videoId || !apiKey || !isWhitelisted(channelId)) return setSongs([])
+    if (!videoId || !apiKey || (enableWhitelist && !isWhitelisted(channelId))) return setSongs([])
 
     fetch(`https://holodex.net/api/v2/videos?id=${videoId}&include=songs`, {
       headers: {

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -16,15 +16,28 @@ import Content from './Content'
 
   let videoId: string | null = null
 
+  const getChannelId = async () => {
+    const channelAnchorSelector = 'ytd-video-owner-renderer a[href*="channel/UC"]:not([href*="stale=1"])'
+    const channelId = /UC[-_0-9A-Za-z]{21}[AQgw]/.exec((await ensureSelector(channelAnchorSelector) as HTMLAnchorElement).href)?.[0]
+
+    // Mark as stale
+    document.querySelectorAll(channelAnchorSelector).forEach((el: HTMLAnchorElement) => {
+      const url = new URL(el.href)
+      url.searchParams.set('stale', '1')
+
+      el.href = url.toString()
+    })
+
+    return channelId
+  }
+
   chrome.runtime.onMessage.addListener(async (message: BrowserMessage, sender) => {
     if (sender.id !== chrome.runtime.id) return
-    
-    const id = (new URLSearchParams(window.location.search)).get('v')
+    const newVideoId = (new URLSearchParams(window.location.search)).get('v')
 
     switch (message.type) {
     case BrowserMessageType.tabStatusChange:
-      if (message.status !== 'complete' || id === videoId) return
-      videoId = id
+      if (message.status !== 'complete' || videoId === newVideoId) return
       break
     case BrowserMessageType.languageChanged:
       i18n.changeLanguage()
@@ -34,14 +47,18 @@ import Content from './Content'
     }
 
     const player = await ensureSelector('.ytd-player') as HTMLElement
+    const channelId = await getChannelId()
 
     root.render(
       <Content
         player={player}
-        videoId={id}
+        videoId={newVideoId}
+        channelId={channelId}
         songsPanelContainer={panelContainer}
         dexLinkContainer={linkContainer}
       />
     )
+
+    videoId = newVideoId
   })
 })()

--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { Trans, useTranslation } from 'react-i18next'
 import { useForm, Controller } from 'react-hook-form'
-import { MdLaunch } from 'react-icons/md'
+import { MdCheck, MdLaunch } from 'react-icons/md'
 import {
   Alert,
   AlertIcon,
@@ -25,6 +25,7 @@ import {
 } from '@chakra-ui/react'
 
 import useStorage from '../../hooks/useStorage'
+import useChannelWhitelist from '../../hooks/useChannelWhitelist'
 import { BrowserMessageType } from '../../common/types/BrowserMessage'
 import { messageAll } from '../../common/utils/message'
 
@@ -32,9 +33,14 @@ const Options = () => {
   const [t, i18n] = useTranslation('options')
   const [showAlert, setShowAlert] = useState(false)
 
+  const [updatingWhitelist, setUpdatingWhitelist] = useState(false)
+  const [updatedWhitelist, setUpdatedWhitelist] = useState(false)
+
   const [apiKey, setApiKey] = useStorage('apiKey', '')
   const [showDexButton, setShowDexButton] = useStorage('showDexButton', true)
   const [showSongControls, setShowSongControls] = useStorage('showSongControls', true)
+
+  const { updateWhitelist } = useChannelWhitelist()
   
   const prefs = { apiKey, showDexButton, showSongControls }
 
@@ -75,6 +81,14 @@ const Options = () => {
     })
   }
 
+  const handleUpdateWhitelist = async () => {
+    setUpdatingWhitelist(true)
+    await updateWhitelist()
+
+    setUpdatingWhitelist(false)
+    setUpdatedWhitelist(true)
+  }
+
   const handleLanguageChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     await i18n.changeLanguage(e.target.value)
     messageAll({ type: BrowserMessageType.languageChanged })
@@ -92,7 +106,7 @@ const Options = () => {
     <form onSubmit={handleSubmit(onSubmit)}>
       {
         showAlert && (
-          <Alert status='success' variant='left-accent' mb='1em'>
+          <Alert status='success' variant='left-accent' mb={2}>
             <AlertIcon />
             <AlertTitle>{t('savedChanges')}</AlertTitle>
           </Alert>
@@ -119,9 +133,9 @@ const Options = () => {
         </FormHelperText>
       </FormControl>
 
-      <Divider my='2em' />
+      <Divider my={4} />
 
-      <VStack spacing='1.5em'>
+      <VStack spacing={3}>
         <FormControl>
           <Flex>
             <FormLabel htmlFor='showSongControls'>{t('showSongControls.label')}</FormLabel>
@@ -151,7 +165,28 @@ const Options = () => {
         </FormControl>
       </VStack>
 
-      <Divider my='2em' />
+      <Divider my={4} />
+
+      <Flex>
+        <Button
+          colorScheme='blue'
+          variant='ghost'
+          mx='-20px'
+          px='20px'
+          borderRadius={0}
+          flexGrow={1}
+          justifyContent='space-between'
+          isLoading={updatingWhitelist}
+          isDisabled={updatedWhitelist}
+          spinnerPlacement='end'
+          rightIcon={updatedWhitelist && <MdCheck />}
+          loadingText={t('updateChannels.title.loading')}
+          onClick={handleUpdateWhitelist}>
+          { updatedWhitelist ? t('updateChannels.title.success') : t('updateChannels.title.default') }
+        </Button>
+      </Flex>
+
+      <Divider my={4} />
 
       <Flex>
         <Select variant='filled' onChange={handleLanguageChange} defaultValue={i18n.language} display='inline-block' width='auto'>

--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -37,8 +37,6 @@ import { messageAll } from '../../common/utils/message'
 const Options = () => {
   const [t, i18n] = useTranslation('options')
   const [showAlert, setShowAlert] = useState(false)
-
-  const [updatingWhitelist, setUpdatingWhitelist] = useState(false)
   const [updatedWhitelist, setUpdatedWhitelist] = useState(false)
 
   const [apiKey, setApiKey] = useStorage('apiKey', '')
@@ -46,7 +44,7 @@ const Options = () => {
   const [showSongControls, setShowSongControls] = useStorage('showSongControls', true)
   const [enableWhitelist, setEnableWhitelist] = useStorage('enableWhitelist', false)
 
-  const { whitelist, updateWhitelist, lastUpdated } = useChannelWhitelist()
+  const { whitelist, updateWhitelist, whitelistLastUpdated, isWhitelistUpdating } = useChannelWhitelist()
   
   const prefs = { apiKey, showDexButton, showSongControls, enableWhitelist }
 
@@ -95,10 +93,7 @@ const Options = () => {
   }
 
   const handleUpdateWhitelist = async () => {
-    setUpdatingWhitelist(true)
     await updateWhitelist()
-
-    setUpdatingWhitelist(false)
     setUpdatedWhitelist(true)
   }
 
@@ -204,13 +199,21 @@ const Options = () => {
             in={watchEnableWhitelist}
             style={{flexGrow: 1}}>
             <VStack align='stretch'>
+              <Stat px='20px'>
+                <StatLabel>{t('whitelistStat.label')}</StatLabel>
+                <StatNumber>{t('whitelistStat.length', { length: whitelistLength })}</StatNumber>
+                <StatHelpText>
+                  { whitelistLastUpdated ? t('whitelistStat.lastUpdated', { whitelistLastUpdated }) : t('whitelistStat.lastUpdatedNever')}
+                </StatHelpText>
+              </Stat>
+
               <Button
                 colorScheme='blue'
                 variant='ghost'
                 px='20px'
                 borderRadius={0}
                 justifyContent='space-between'
-                isLoading={updatingWhitelist}
+                isLoading={isWhitelistUpdating}
                 isDisabled={updatedWhitelist}
                 spinnerPlacement='end'
                 rightIcon={updatedWhitelist && <MdCheck />}
@@ -218,14 +221,6 @@ const Options = () => {
                 onClick={handleUpdateWhitelist}>
                 { updatedWhitelist ? t('updateChannels.title.success') : t('updateChannels.title.default') }
               </Button>
-
-              <Stat px='20px'>
-                <StatLabel>{t('whitelistStat.label')}</StatLabel>
-                <StatNumber>{t('whitelistStat.length', { length: whitelistLength })}</StatNumber>
-                <StatHelpText>
-                  { lastUpdated ? t('whitelistStat.lastUpdated', { lastUpdated }) : t('whitelistStat.lastUpdatedNever')}
-                </StatHelpText>
-              </Stat>
             </VStack>
           </Collapse>
         </Flex>

--- a/src/pages/options/index.scss
+++ b/src/pages/options/index.scss
@@ -1,4 +1,4 @@
 body {
-    margin: 20px !important;
+    margin: 20px 20px 0 20px !important;
     min-width: 360px;
 }


### PR DESCRIPTION
This PR seeks to resolve the privacy issues raised in #1 by implementing an offline whitelist of channels. 

# Implementation details
- A new option is added to enable/disable whitelisting
- If enabled, the whitelist will be automatically updated weekly, but the update can also be triggered manually
- When playing a video, we attempt to extract the channel ID from the channel URL. In case of custom URLs, an additional fetch request will be made. 

Closes #1.