### PR TITLE
Return promises in async language detector

### DIFF
--- a/src/common/i18next/ExtensionLanguageDetect.ts
+++ b/src/common/i18next/ExtensionLanguageDetect.ts
@@ -9,11 +9,11 @@ const ExtensionLanguageDetect : () => LanguageDetectorAsyncModule & { services?:
     init(services) {
       this.services = services
     },
-    async detect(callback) {
+    async detect() {
       const { language } = await chrome.storage.local.get('language')
-      if (language) return callback(language)
+      if (language) return language
   
-      callback(this.services?.languageUtils.getBestMatchFromCodes(await chrome.i18n.getAcceptLanguages()))
+      return this.services?.languageUtils.getBestMatchFromCodes(await chrome.i18n.getAcceptLanguages())
     },
     async cacheUserLanguage(language) {
       await chrome.storage.local.set({ language })


### PR DESCRIPTION
A recent change to i18next allows async language detectors to return promises instead of using the callback function. The language detector has been updated to reflect this change.

See https://github.com/i18next/i18next/pull/1879#issuecomment-1345369066
