### PR TITLE
Fix deprecated import assertions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ import CopyWebpackPlugin from 'copy-webpack-plugin'
 import { CleanWebpackPlugin } from 'clean-webpack-plugin'
 import { isNotJunk } from 'junk'
 
-import packageJson from './package.json' assert {type: 'json'}
+import packageJson from './package.json' with {type: 'json'}
 
 
 const __filename = fileURLToPath(import.meta.url)


### PR DESCRIPTION
### What is the problem this feature will solve?
`npm run build` will fail in Node.js 22, because the `assert` syntax has been replaced by `with`.

See 
https://github.com/nodejs/node/issues/51622
https://v8.dev/features/import-attributes#deprecation-and-eventual-removal-of-assert